### PR TITLE
Bullet and help fix

### DIFF
--- a/09B-DBM-Analysis-SigTesting.Rmd
+++ b/09B-DBM-Analysis-SigTesting.Rmd
@@ -18,6 +18,7 @@ library(here)
 
 ## The DBM sampling model
 The figure-of-merit has three indices:  
+
 * A treatment index $i$, where $i$ runs from 1 to $I$, where $I$ is the total number of treatments.  
 * A reader index $j$, where $j$ runs from 1 to $J$, where $J$ is the total number of readers.  
 * The case-sample index $\{c\}$, where  $\{1\}$  i.e., $c$ = 1, denotes a set of cases, $K_1$ non-diseased and $K_2$ diseased, interpreted by all readers in all treatments, and other integer values of $c$ correspond to other independent sets of cases that, although not in fact interpreted by the readers, could potentially be “interpreted” using resampling methods such as the bootstrap or the jackknife. 
@@ -373,7 +374,8 @@ The *critical* value of the F-distribution, denoted $F_{1-\alpha,\text{ndf},\tex
 (\#eq:critValFStat)
 \end{equation}
 
-The critical value $F_{1-\alpha,\text{ndf},\text{ddf}_H}$ increases as $\alpha$ decreases. The value of $\alpha$, generally chosen to be 0.05, termed the *nominal* $\alpha$, is fixed. The decision rule is that if $F_{DBM} > F_{1-\alpha, \text{ndf}, \text{ddf}_H}$ one rejects the NH and otherwise one does not. It follows, from the definition of $F_{DBM}$, Equation \@ref(eq:FStatHillis), that rejection of the NH is more likely to occur if: 
+The critical value $F_{1-\alpha,\text{ndf},\text{ddf}_H}$ increases as $\alpha$ decreases. The value of $\alpha$, generally chosen to be 0.05, termed the *nominal* $\alpha$, is fixed. The decision rule is that if $F_{DBM} > F_{1-\alpha, \text{ndf}, \text{ddf}_H}$ one rejects the NH and otherwise one does not. It follows, from the definition of $F_{DBM}$, Equation \@ref(eq:FStatHillis), that rejection of the NH is more likely to occur if:
+
 * $F_{DBM}$ is large, which occurs if $MST$ is large, meaning the treatment effect is large
 * $MSTR + \max \left (MSTC - MSTRC,0  \right )$ is small, see comments following TBA \@ref(eq:pseudoValPrime) Eqn. (9.23). 
 *	$\alpha$ is large: for then $F_{1-\alpha,\text{ndf},\text{ddf}_H}$ decreases and is more likely to be exceeded by the observed value of $F_{DBM}$. 

--- a/10B-OR-AnalysisSigTesting.Rmd
+++ b/10B-OR-AnalysisSigTesting.Rmd
@@ -116,13 +116,9 @@ The critical value of the F-statistic for rejection of the null hypothesis is $F
 * Rejection of the NH is more likely if $MS(T)$ increases, meaning the treatment effect is larger; 
 
 * $MS(TR)$ is smaller, meaning there is less contamination of the treatment effect by treatment-reader variability; 
-
 * The greater of $\text{Cov2}$ or $\text{Cov3}$, which is usually $\text{Cov2}$, decreases, meaning there is less "noise" in the measurement due to between-reader variability. Recall that $\text{Cov2}$ involves different-reader same-treatment pairings.  
-
 * $\alpha$ increases, meaning one is allowing a greater probability of Type I errors; 
-
 * $\text{ndf}$ increases, as this lowers the critical value of the F-statistic. With more treatment pairings, the chance that at least one paired-difference will reject the NH is larger. 
-
 * $\text{ddf}_H$ increases, as this lowers the critical value of the F-statistic. 
 
 The p-value of the test is the probability, under the NH, that an equal or larger value of the F-statistic than $F_{ORH}$ could be observed by chance. In other words, it is the area under the F-distribution $F_{\text{ndf},\text{ddf}_H}$ that lies above the observed value $F_{ORH}$:

--- a/10C-OR-AnalysisApplications.Rmd
+++ b/10C-OR-AnalysisApplications.Rmd
@@ -79,10 +79,10 @@ print(vc)
 * The next step is the calculate the NH testing statistic. 
 * The relevant equation is Eqn. \@ref(eq:F-ORH-RRRC). 
 * `vc` contains the values needed in this equation, as follows:
-+ MS(T) is in `vc$TRanova["T", "MS"]`, whose value is `r vc$TRanova["T", "MS"]`. 
-+ MS(TR) is in `vc$TRanova["TR", "MS"]`, whose value is `r vc$TRanova["TR", "MS"]`. 
-+ `Cov2` is in `vc$VarCom["Cov2", "Estimates"]`, whose value is `r vc$VarCom["Cov2", "Estimates"]`. 
-+ `Cov3` is in `vc$VarCom["Cov3", "Estimates"]`, whose value is `r vc$VarCom["Cov3", "Estimates"]`. 
+    + MS(T) is in `vc$TRanova["T", "MS"]`, whose value is `r vc$TRanova["T", "MS"]`. 
+    + MS(TR) is in `vc$TRanova["TR", "MS"]`, whose value is `r vc$TRanova["TR", "MS"]`. 
+    + `Cov2` is in `vc$VarCom["Cov2", "Estimates"]`, whose value is `r vc$VarCom["Cov2", "Estimates"]`. 
+    + `Cov3` is in `vc$VarCom["Cov3", "Estimates"]`, whose value is `r vc$VarCom["Cov3", "Estimates"]`. 
 
 Applying Eqn. \@ref(eq:F-ORH-RRRC) one gets (`den` is the denominator on the right hand side of the referenced equation) and F_ORH_RRRC is the value of the F-statistic:
 

--- a/10C-OR-AnalysisApplications.Rmd
+++ b/10C-OR-AnalysisApplications.Rmd
@@ -393,7 +393,7 @@ In the interest of clarity, in the first example using the `RJafroc` package the
 
 Online help on the `StSignificanceTesting()` function is available:
 
-```{r}
+```{r eval=FALSE}
 ?`StSignificanceTesting`
 ```
 

--- a/11-ROCSampleSizeDBM.Rmd
+++ b/11-ROCSampleSizeDBM.Rmd
@@ -54,6 +54,7 @@ Typically, one aims for $\beta = 0.2$  or less, i.e., a statistical power of 80%
 
 ### Dependence of statistical power on estimates of model parameters {#RocSampleSizeDBM-dependence-of-stats-power}
 Examination of the expression for  , Eqn. (11.5), shows that statistical power increases if:
+
 * The numerator is large. This occurs if: (a) the anticipated effect-size $d$ is large. Since effect-size enters as the *square*, TBA Eqn. (11.8), it is has a particularly strong effect; (b) If $J \times K$ is large. Both of these results should be obvious, as a large effect size and a large sample size should result in increased probability of rejecting the NH. 
 * The denominator is small. The first term in the denominator is  $\left ( \sigma_{\epsilon}^2 + \sigma_{\tau RC}^2 \right )$. These two terms cannot be separated. This is the residual variability of the jackknife pseudovalues. It should make sense that the smaller the variability, the larger is the non-centrality parameter and the statistical power. 
 * The next term in the denominator is $K\sigma_{\tau R}^2$, the treatment-reader variance component multiplied by the total number of cases. The reader variance $\sigma_{R}^2$ has no effect on statistical power, because it has an equal effect on both treatments and cancels out in the difference. Instead, it is the treatment-reader variance $\sigma_{R}^2$  that contributes "noise" tending to confound the estimate of the effect-size. 

--- a/11-ROCSampleSizeOR.Rmd
+++ b/11-ROCSampleSizeOR.Rmd
@@ -86,6 +86,7 @@ For two treatments, since the individual treatment effects must be the negatives
 
 ### Dependence of statistical power on estimates of model parameters {#RocSampleSizeOR-dependence-of-stats-power}
 Examination of the expression for  , Eqn. (11.5), shows that statistical power increases if:
+
 * The numerator is large. This occurs if: (a) the anticipated effect-size $d$ is large. Since effect-size enters as the *square*, TBA Eqn. (11.8), it is has a particularly strong effect; (b) If $J \times K$ is large. Both of these results should be obvious, as a large effect size and a large sample size should result in increased probability of rejecting the NH. 
 * The denominator is small. The first term in the denominator is  $\left ( \sigma_{Y;\epsilon}^2 + \sigma_{Y;\tau RC}^2 \right )$. These two terms cannot be separated. This is the residual variability of the jackknife pseudovalues. It should make sense that the smaller the variability, the larger is the non-centrality parameter and the statistical power. 
 * The next term in the denominator is $K\sigma_{Y;\tau R}^2$, the treatment-reader variance component multiplied by the total number of cases. The reader variance $\sigma_{Y;R}^2$ has no effect on statistical power, because it has an equal effect on both treatments and cancels out in the difference. Instead, it is the treatment-reader variance $\sigma_{Y;R}^2$  that contributes "noise" tending to confound the estimate of the effect-size. 


### PR DESCRIPTION
Fixes a handful of instances where bullet points were appearing within a paragraph rather than a separate list.

Commit ed5eb46 groups bullets together into one list.

The 1d3be72 commit stops the StSignificanceTesting help being displayed. When I have built the book, the help is rendered to the command line and pauses the build until I have dismissed it. Do you want the the help text to be displayed on the page it is called from (or perhaps rendered in an appendix?)