### PR TITLE
Fix Barlow table overflow

### DIFF
--- a/04-ratings-paradigm.Rmd
+++ b/04-ratings-paradigm.Rmd
@@ -412,14 +412,20 @@ colnames(df) <- c("Total number \nof mammograms",
                   "Mammograms without \nbreast cancer (percent)",
                   "Mammograms with \nbreast cancer  (percent)",
                   "Cancers per 1000 \nscreening mammograms")
-rownames(df) <- c("1:Normal\n",
+rownames(df) <- c("1: Normal\n",
                   "2: Benign finding\n",
                   "3: Probably benign, \nrecommend normal or short term follow up",
                   "3+: Probably benign, \nrecommend immediate follow up",
                   "0: Need additional \nimaging evaluation",
                   "4: Suspicious finding, \nbiopsy should be considered",
                   "5: Highly suggestive \nof malignancy")
-knitr::kable(df, caption = "The Barlow et al study: the ordering of the BI-RADS ratings in the first column correlates with cancer-rate in the last column.", escape = FALSE)
+knitr::kable(df, caption = "The Barlow et al study: the ordering of the BI-RADS ratings in the first column correlates with cancer-rate in the last column.", escape = FALSE) %>% 
+kable_styling(latex_options =c("scale_down")) %>% 
+column_spec(1,width ="11em") %>%
+column_spec(2,width ="8em") %>% 
+column_spec(3,width ="8em") %>% 
+column_spec(4,width ="8em") %>% 
+column_spec(5,width ="8em")
 ```
 
 The use of the BI-RADS ratings shown in Table \@ref(tab:BIRADS-study) has been criticized [@RN2166] in an editorial titled: 


### PR DESCRIPTION
- as KableExtra is loaded, use `column_spec` to set width of each column
- this manages the wrapping
- `latex_options =c("scale_down")` fits the table to the page