### PR TITLE
Add PDF rendering to deploy_bookdown.yaml

### DIFF
--- a/.github/workflows/deploy_bookdown.yaml
+++ b/.github/workflows/deploy_bookdown.yaml
@@ -14,14 +14,19 @@ jobs:
       - uses: actions/checkout@v1
       - uses: r-lib/actions/setup-r@v1
       - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-tinytex@v1
       - name: Install rmarkdown
         run: Rscript -e 'install.packages(c("rmarkdown","bookdown","here","remotes","ggplot2","kableExtra","abind","dplyr","grid","gridExtra","pBrackets","seqinr"))'
       - name: Install Rjafroc
         run: Rscript -e 'remotes::install_github("dpc10ster/RJafroc")'
-      - name: Render html Book
+      - name: Render PDF Book
+        run: Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: pdf
+          path: docs/
+      - name: Render HTML Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
-      - name: Render pdf Book
-        run: Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::pdf_book")'
       - uses: actions/upload-artifact@v1
         with:
           name: docs


### PR DESCRIPTION
- load tinytex
- render PDF into docs folder
- make an artifact of the docs folder called "pdf"
- this contains the generated files for making the PDF
- (the some files in docs folder later overwritten by the HTML build - captured in the "docs" artifact)
- (PDF and HTML committed into gh-pages)